### PR TITLE
Removed RunTimeError while modifying OrderedDict in remove_fc()

### DIFF
--- a/bpm/model/resnet.py
+++ b/bpm/model/resnet.py
@@ -149,7 +149,7 @@ class ResNet(nn.Module):
 
 def remove_fc(state_dict):
   """Remove the fc layer parameters from state_dict."""
-  for key, value in state_dict.items():
+  for key in list(state_dict):
     if key.startswith('fc.'):
       del state_dict[key]
   return state_dict


### PR DESCRIPTION
The looping statement throws `RunTimeError` while looping over the `OrderedDict` in the function `remove_fc`. Rectified it according to this solution: https://stackoverflow.com/a/42330961/9762699